### PR TITLE
Add {set,clear}{Interval,Timer} to globals

### DIFF
--- a/scripts/generate-configs.js
+++ b/scripts/generate-configs.js
@@ -29,7 +29,11 @@ writeConfigs({
       ...standardConfig,
       env: splitNodeEnv.no,
       globals: {
+        clearInterval: 'readonly',
+        clearTimeout: 'readonly',
         console: 'readonly',
+        setInterval: 'readonly',
+        setTimeout: 'readonly',
         ...standardConfig.globals
       },
       plugins: splitNodePlugins.no,


### PR DESCRIPTION
Running without `node` support is pretty usable, aside from these four methods. They are so ancient & so fundamental, it's weird to not have them available. Plus, everyone supports them, from Browsers to Node.js to little embedded systems (Espurino).